### PR TITLE
Use `scikit-learn` instead in requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 numpy
 pandas
 statsmodels
-sklearn
+scikit-learn
 matplotlib
 coverage


### PR DESCRIPTION
According to PyPI, https://pypi.org/project/sklearn/,

```Use scikit-learn instead.```

This will help keep requirements.txt in downstream packages tidy.