### PR TITLE
Fix to setup.py for sklearn deprecation

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ setuptools.setup(
         "numpy",
         "pandas",
         "matplotlib",
-        "sklearn",
+        "scikit-learn",
         "scipy",
         "statsmodels",
     ],


### PR DESCRIPTION
setup.py still contains a reference to the deprecated sklearn

This causes errors when attempting to pip install pyALE with the env variable `SKLEARN_ALLOW_DEPRECATED_SKLEARN_PACKAGE_INSTALL=False` (as per https://pypi.org/project/sklearn/) 