### PR TITLE
fix 2D display when variables in very different scales

### DIFF
--- a/PyALE/_src/ALE_2D.py
+++ b/PyALE/_src/ALE_2D.py
@@ -234,7 +234,10 @@ def plot_2D_continuous_eff(eff_grid, contour=False, fig=None, ax=None):
     if fig is None and ax is None:
         fig, ax = plt.subplots()
     im = ax.imshow(
-        eff_grid, origin="lower", extent=[X.min(), X.max(), Y.min(), Y.max()]
+        eff_grid,
+        origin="lower",
+        extent=[X.min(), X.max(), Y.min(), Y.max()],
+        aspect='auto',
     )
     if contour:
         imc = ax.contour(X, Y, eff_grid, colors="black")

--- a/PyALE/_src/ALE_2D.py
+++ b/PyALE/_src/ALE_2D.py
@@ -237,7 +237,7 @@ def plot_2D_continuous_eff(eff_grid, contour=False, fig=None, ax=None):
         eff_grid,
         origin="lower",
         extent=[X.min(), X.max(), Y.min(), Y.max()],
-        aspect='auto',
+        aspect="auto",
     )
     if contour:
         imc = ax.contour(X, Y, eff_grid, colors="black")


### PR DESCRIPTION
@DanaJomar 

When variables are in very different dimensions, say one varies from 1 to 10 and the other one from 1 to 5000, the plot is so narrow that you can't see the image. This is corrected by addig the `param aspect="auto"`