### PR TITLE
allow option not to impute empty cells in 2D plots

### DIFF
--- a/PyALE/_ALE_generic.py
+++ b/PyALE/_ALE_generic.py
@@ -22,6 +22,7 @@ def ale(
     feature,
     feature_type="auto",
     grid_size=20,
+    impute_empty_cells=True,
     include_CI=True,
     C=0.95,
     encode_fun=None,
@@ -83,6 +84,10 @@ def ale(
     ----
         An integer indicating the number of intervals into which the feature range
         is divided.
+    impute_empty_cells
+    ----
+        A boolean indicating if empty cells created for 2-D ale plots should be imputed
+        (`True`) or treated as zero (`False`).
     include_CI
     ----
         A boolean, if True the confidence interval of the effect is returned with
@@ -147,6 +152,8 @@ def ale(
             "The argument 'feature_type' should be 'auto', 'continuous', "
             "'discrete', or 'categorical'"
         )
+    if not isinstance(impute_empty_cells, bool):
+        raise Exception("The argument 'impute_empty_cells' should be True or False.")
 
     # if one feature is given
     if len(feature) == 1:
@@ -243,6 +250,7 @@ def ale(
             "model": model,
             "features": feature,
             "grid_size": grid_size,
+            "impute_empty_cells": impute_empty_cells,
         }
         arg_plot = {
             "contour": contour,

--- a/PyALE/_src/ALE_2D.py
+++ b/PyALE/_src/ALE_2D.py
@@ -94,11 +94,11 @@ def aleplot_2D_continuous(X, model, features, grid_size=40, impute_empty_cells=T
     sizes_0 = sizes_df.groupby(level=0).sum().reindex(range(len(bins_0)), fill_value=0)
     sizes_1 = sizes_df.groupby(level=1).sum().reindex(range(len(bins_0)), fill_value=0)
 
-    if impute_empty_cells is True:
-        eff_df = delta_df["mean"].reindex(index_combinations, fill_value=np.nan)
+    eff_df = delta_df["mean"].reindex(index_combinations, fill_value=np.nan)
 
-        # ============== fill in the effects of missing combinations ================= #
-        # ============== use the kd-tree nearest neighbour algorithm ================= #
+    # ============== fill in the effects of missing combinations ================= #
+    # ============== use the kd-tree nearest neighbour algorithm ================= #
+    if impute_empty_cells is True:
         row_na_idx = np.where(eff_df.isna())[0]
         feat0_code_na = eff_df.iloc[row_na_idx].index.get_level_values(0)
         feat1_code_na = eff_df.iloc[row_na_idx].index.get_level_values(1)
@@ -135,9 +135,6 @@ def aleplot_2D_continuous(X, model, features, grid_size=40, impute_empty_cells=T
             eff_df.iloc[row_na_idx] = eff_df.iloc[
                 row_notna_idx[indices.flatten()]
             ].to_list()
-
-    else:
-        eff_df = delta_df["mean"].reindex(index_combinations, fill_value=0)
 
     # ============== cumulative sum of the difference ================= #
     eff_df = eff_df.groupby(level=0).cumsum().groupby(level=1).cumsum()


### PR DESCRIPTION
As per [Molnar](https://christophm.github.io/interpretable-ml-book/ale.html) empty cells generated during the the estimation of 2D ALE plots can be estimated as done in the current implementation, or blacked out.

If we leave the nan, they will appear as empty squares in the plot. 

@DanaJomar 

If you are happy with this functionality I could add an example. 